### PR TITLE
Changed malloc from using a static 20000000 to allocating memory based on the number of lines in the reference files

### DIFF
--- a/src/intersect_kmer_lists_filelist.c
+++ b/src/intersect_kmer_lists_filelist.c
@@ -5,7 +5,7 @@ first list (assumed to be from reads) and all other lists (assumed to be from a
 set of reference genomes).
 
 Author: ulf.schaefer@phe.gov.uk 31Jul2013
-Modified: tobingallop@yahoo.co.uk 20Nov2018
+Modified: sam.gallop@nbi.ac.uk 20Nov2018
 
 ****************************************************************/
 

--- a/src/intersect_kmer_lists_filelist.c
+++ b/src/intersect_kmer_lists_filelist.c
@@ -1,12 +1,13 @@
-/* ***************************************************************
+/****************************************************************
 
 Takes a list of input kmer list files and prints the similarity between the
 first list (assumed to be from reads) and all other lists (assumed to be from a 
 set of reference genomes).
 
 Author: ulf.schaefer@phe.gov.uk 31Jul2013
+Modified: tobingallop@yahoo.co.uk 20Nov2018
 
-*************************************************************** */
+****************************************************************/
 
 #include <stdio.h>
 #include <string.h>
@@ -14,109 +15,131 @@ Author: ulf.schaefer@phe.gov.uk 31Jul2013
 #include <math.h>
 #include <glob.h>
 #include <dirent.h>
+#include <libgen.h>
 
-#define INILISTLEN 20000000
+#define VERSION 0.2
 
-// --------------------------------------------------------------------------------------------------------
+void displayUsage(char*);
+long long countFileLines(FILE*);
 
-int main(int argv, const char **args)
+//---------------------------------------------------------------
+int main(int argc,  char *argv[])
 {
-    time_t start;
-    start = time(NULL);
+ if (argc < 3 ) {
+  displayUsage(argv[0]);
+  exit(1);
+ }
 
-    if (argv < 3 )
-    {
-        printf("\nUsage: intersect_kmer_lists_filelist [readkmerlist] [refkmerlist_1] [refkmerlist_2] ... [refkmerlist_n]\n\n");
-        exit(1);
-    }
-      
-    FILE *fListFile1;
+ int k = 0;    
+ long long i = 0, j = 0, c = 0;
+ long long llLen1 = 0, llLen2 = 0, lines = 0;
+ float flSim = 0.0, flDist = 0.0;
+ FILE *fListFile1; 
+ FILE *fListFile2;
+ long long *laList1, *laList2;
 
-    if ((fListFile1 = fopen(args[1], "r")) == NULL)
-    {
-        fprintf(stderr, "Can't open file: %s\n\n", args[1]);
-        exit(1);
-    }
-        
-    long long *laList1, *laList2;
-    if ((laList1=(long long*)malloc(sizeof(long long)*INILISTLEN)) == NULL)
-    {
-        fprintf(stderr, "Memory allocation failed\n");
-        exit(2);
-    }
-    memset(laList1, 0, sizeof(long long)*INILISTLEN);
+ if ((fListFile1 = fopen(argv[1], "r")) == NULL) {
+  fprintf(stderr, "Can't open file: %s\n", argv[1]);
+  exit(1);
+ }
+ 
+ lines = countFileLines(fListFile1);
+ //fprintf(stdout, "%s contains %lld lines\n", argv[1], lines);
+ 
+ if ((laList1 = (long long*)malloc(sizeof(long long) * lines)) == NULL) {
+  fprintf(stderr, "Memory allocation failed\n");
+  exit(2);
+ }
+ memset(laList1, 0, sizeof(long long) * lines);
+ 
+ fseek(fListFile1, 0, SEEK_SET);
+ while(!feof(fListFile1)) {
+  fscanf(fListFile1, "%lld\n", &laList1[llLen1]);
+  llLen1++;
+ }
 
-    if ((laList2=(long long*)malloc(sizeof(long long)*INILISTLEN)) == NULL)
-    {
-        fprintf(stderr, "Memory allocation failed\n");
-        exit(2);
-    }
-    memset(laList2, 0, sizeof(long long)*INILISTLEN);
-    
-    long long llLen1=0, llLen2=0;
-    while(!feof(fListFile1))
-    {
-        fscanf(fListFile1,"%lld\n",&laList1[llLen1]);
-        llLen1++;
-    }
+ for (k = 2; k < argc; k++) {                  
+  if ((fListFile2 = fopen(argv[k], "r")) == NULL) {
+   fprintf(stderr, "Can't open file: %s\n", argv[k]);
+   exit(1);
+  }
+  
+  lines = countFileLines(fListFile2);
+  //fprintf(stdout, "%s contains %lld lines\n", argv[k], lines);
+  
+  if ((laList2 = (long long*)malloc(sizeof(long long) * lines)) == NULL) {
+   fprintf(stderr, "Memory allocation failed\n");
+   exit(2);
+  }
+  memset(laList2, 0, sizeof(long long) * lines);
 
-    int k=0;    
-    long long i=0, j=0, c=0;
-    float flSim=0.0, flDist=0.0;
-    FILE *fListFile2;
-    for (k=2; k<argv; k++)
-    {                  
-        if ((fListFile2 = fopen(args[k], "r")) == NULL)
-        {
-            fprintf(stderr, "Can't open file: %s\n\n", args[k]);
-            exit(1);
-        }
+  llLen2 = 0;
+  fseek(fListFile2, 0, SEEK_SET);
+  while(!feof(fListFile2)) {
+   fscanf(fListFile2, "%lld\n", &laList2[llLen2]);
+   llLen2++;
+  }        
 
-        llLen2 = 0;
-        while(!feof(fListFile2))
-        {
-            fscanf(fListFile2,"%lld\n",&laList2[llLen2]);
-            llLen2++;
-        }        
+  i = 0, j = 0, c = 0;
+  while (i < llLen1 && j < llLen2) {
+   if (laList1[i] == laList2[j]) {
+    i++; j++; c++; continue;
+   }
+   if (laList1[i] > laList2[j]) {
+    j++;
+   } else {
+    i++;
+   }
+  }
 
-        i=0, j=0, c=0;
-        while (i<llLen1 && j<llLen2)
-        {
-            if (laList1[i] == laList2[j])
-            {
-                i++; j++; c++; continue;
-            }
-            if (laList1[i] > laList2[j])
-            {
-                j++;
-            }
-            else
-            {
-                i++;
-            }
-        }
+  // Richa: "Similarity is simply percentage of 18mers in reference seen in read set as well."
+  flSim = (float)c / ( (float)llLen2 / 100.0);
 
-        // Richa: "Similarity is simply percentage of 18mers in reference seen in read set as well."
-        flSim = (float)c / ( (float)llLen2 / 100.0);
-        
-        // Similarity = percentage of kmers in reads seen in reference as well     
-        // flSim = (float)c / ( (float)llLen1 / 100.0); 
-                
-        flDist = 100.0 - flSim;
+  // Similarity = percentage of kmers in reads seen in reference as well     
+  // flSim = (float)c / ( (float)llLen1 / 100.0); 
 
-        printf("%f\t%f\t%s\n", flSim, flDist, args[k]);
-        
-        fclose(fListFile2);
-        memset(laList2, 0, sizeof(long long)*INILISTLEN);
-    }
-    
-    free(laList1);
-    free(laList2);
-    fclose(fListFile1);
+  flDist = 100.0 - flSim;
+  fprintf(stdout, "%f\t%f\t%s\n", flSim, flDist, argv[k]);
+  fclose(fListFile2);
+  free(laList2);
+ }
 
-    return 0;
+ fclose(fListFile1);
+ free(laList1);
+ return 0;
 }
 
-// ------------------------------------------------------------------
+//---------------------------------------------------------------
+void displayUsage(char* parent)
+{
+ char *app;
+ char *path = strdup(parent);
+ app = basename(path);
+ fprintf(stdout, "\n%s v%0.1f\n", app, VERSION);
+ fprintf(stdout, "Usage: %s [readkmerlist] [refkmerlist_1] [refkmerlist_2] ... [refkmerlist_n]\n", app);
+ fprintf(stdout, " [refkmerlist]       - File containing a list of sorted kmers. This is generate off of a fastq\n");
+ fprintf(stdout, "                     - file (reads) and used to investigate similarities against the set of\n");
+ fprintf(stdout, "                     - reference genomes\n");
+ fprintf(stdout, " [refkmerlist_1,2,n] - List of files containing sorted kmers. These files are the reference\n");
+ fprintf(stdout, "                     - genomes used to compare against the first kmer list (reads)\n");
+}
 
-// eof
+//---------------------------------------------------------------
+long long countFileLines(FILE *fp)
+{
+ char ch;
+ long long linecount = 0;
+ 
+ // check if file is open
+ if (fp) {
+  // read character from file until EOF
+  while ((ch = getc(fp)) != EOF) {
+   if (ch == '\n')
+    ++linecount;
+  }
+ } else {
+  fprintf(stderr, "File is not open\n");
+ }
+ 
+ return linecount;
+}


### PR DESCRIPTION
Encountered a segmentation fault when running intersect_kmer_lists_filelist. The number of kmers exceeds 20000000, and results in the segfault when attempting the write to memory that hasn't been allocated. Rather than simply increase the number in the DEFINE it seemed more appropriate to dynamically allocate memory based on the number of lines in the files. To achieve this I created a line count function and moved one of the malloc statements to within the main while loop. I believe, though I can't be 100%, it may fix issue #3. This approach should also reduce the overall memory footprint.

Along with the change to the malloc, I've made a superfluous change to the usage display by putting it into a separate function.